### PR TITLE
Fix name for AMWA IS-04 Registry

### DIFF
--- a/connector/doc/AMWA_NMOS_IS-04_Registry.md
+++ b/connector/doc/AMWA_NMOS_IS-04_Registry.md
@@ -1,8 +1,8 @@
 ---
-uid: Connector_help_AMWA_NMOS_IS-04
+uid: Connector_help_AMWA_NMOS_IS-04_Registry
 ---
 
-# AMWA NMOS IS-04
+# AMWA NMOS IS-04 Registry
 
 NMOS is a family name for specifications produced by the Advanced Media Workflow Association related to networked media for professional applications.
 

--- a/connector/toc.yml
+++ b/connector/toc.yml
@@ -425,7 +425,7 @@
 - name: AMWA
   items:
   - name: AMWA NMOS IS-04
-    topicUid: Connector_help_AMWA_NMOS_IS-04
+    topicUid: Connector_help_AMWA_NMOS_IS-04_Registry
   - name: AMWA NMOS IS-05
     topicUid: Connector_help_AMWA_NMOS_IS-05
 - name: AnaCom


### PR DESCRIPTION
The correct connector name is AMWA NMOS IS-04 Registry. (see entry on catalog [AMWA NMOS IS-04 Registry](https://catalog.dataminer.services/details/connector/6923))