### PR TITLE
Update CISCO_Nexus.md

### DIFF
--- a/connector/doc/CISCO_Nexus.md
+++ b/connector/doc/CISCO_Nexus.md
@@ -21,10 +21,10 @@ The connector uses an **SNMP** connection and **DCF** integration to monitor Cis
 | 3.0.1.x **[Obsolete - see 3.0.2.x]** | Removed duplicate Interfaces table introduced in 3.0.0.24. | Yes | Yes |
 | 3.0.2.x **[Obsolete - see 3.0.3.x]** | Changed display key of interface tables. Changed API polling table to a complete polling table. | Yes | Yes |
 | 3.0.3.x **[Obsolete - see 3.0.4.x]** | Reworked VTP VLAN table to support both SNMP and NX API polling. | Yes | Yes |
-| 3.0.4.x | Improved display keys of RTP Flow and RTP Flow Errors tables. | Yes | Yes |
+| 3.0.4.x **[Obsolete - see 3.0.5.x]** | Improved display keys of RTP Flow and RTP Flow Errors tables. | Yes | Yes |
 | 3.0.5.x [SLC Main] | OpenConfig implementation. | Yes | Yes |
-| 3.0.6.x | Added VRF group information and reworked IGMP table, Multicast Route Detail table, and BGP Peer table. | Yes |Yes |
-| 4.0.0.x | SNMPv3 version (based on version 1.0.0.9). | No | Yes |
+| 3.0.6.x **[Obsolete - see 3.0.5.x]** | Added VRF group information and rework for IGMP table, Multicast Route Detail table, and BGP Peer tables.| Yes |Yes |
+
 
 ### Product Info
 
@@ -40,7 +40,6 @@ The connector uses an **SNMP** connection and **DCF** integration to monitor Cis
 | 3.0.4.x   | 7.0(8)N1(1)            |
 | 3.0.5.x   | 7.0(8)N1(1)            |
 | 3.0.6.x   | 7.0(8)N1(1)            |
-| 4.0.0.x   | 7.0(8)N1(1)            |
 
 ## Configuration
 


### PR DESCRIPTION
Marked 3.0.6.X to obsolete branch. Removed 4.0.0.X from the driver's help.
@MariekeGO Please help to review and update this ASAP, thank you.


