### PR TITLE
Spectrum simulator update

### DIFF
--- a/connector/doc/Skyline_Spectrum_Simulation.md
+++ b/connector/doc/Skyline_Spectrum_Simulation.md
@@ -40,13 +40,33 @@ This page contains the spectrum analyzer, allowing you to view the simulated tra
 
 ### General
 
-On this page, you can configure the basic parameters required to create the simulated trace.
+This page contains general information, as well as the following parameters:
 
-It has two modes:
+- **Track Parameter Sets**: Open the button next to this parameter to open a tracking window. This window allows you to trace which parameter sets were done. In the window, sets will only be logged if the **Track Sets** parameter is enabled. If **Track Status Sets** is also enabled, status sets (communication between SLSpectrum and the protocol, e.g. requesting a new trace) are also logged.
 
-- The *Center Trace Pattern* mode creates a waveform at the center of the spectrum analyzer trace. The type of waveform is based on the value of the Trace Pattern parameter.
+- **Simulation Mode**: Allows you to switch between the two different modes of the connector:
 
-- The *Carriers from Table* mode creates a waveform based on the Center Frequency, Bandwidth, and Amplitude specified in the Carrier Table.
+  - The *Center Trace Pattern* mode creates a waveform at the center of the spectrum analyzer trace. The type of waveform is based on the value of the Trace Pattern parameter.
+
+  - The *Carriers from Table* mode creates a waveform based on the Center Frequency, Bandwidth, and Amplitude specified in the Carrier Table.
+
+- **Trace pattern**: Allows you to select a specific trace pattern instead of the default pattern. The following patterns are available:
+
+  - *Default*: A single flat line at the center of the trace window, simulating no available signals or carriers.
+
+  - *Jump Up*: A single spike at the center of the window, wider than the channel pattern. This can be used to simulate e.g. a band pass filter.
+
+  - *Jump Down*: Inverse pattern of *Jump Up*. This can be used to simulate e.g. a notch filter.
+
+  - *Channel*: A single spike in the center of the trace window, simulating a typical view of one channel.
+
+  - *Band*: A set of 8 spikes spread over the trace window, simulating a band with several channels.
+
+- **Floor**: A single line in the lower part of the trace window, simulating no available signals or carriers.
+
+- **Noise**: Allows you to disable noise in the simulated pattern.
+
+- **Noise depth**: Allows you to modify the amount of random noise added to the simulated pattern, so that you can for instance simulate environments with poor reception.
 
 ### Tracking
 
@@ -54,7 +74,7 @@ This page allows you to trace which sets have been made on the spectrum analyzer
 
 ### Mirror Values
 
-The parameters on this page mirror the 64xxx special spectrum parameters.
+This page shows the current values of the spectrum interfacing parameters and allows you to change them as if they were changed directly on the device. Note that the connector will automatically sync start/stop frequency or center frequency/frequency span if one of these settings is changed.
 
 ### Measurement Points
 

--- a/connector/doc/Skyline_Spectrum_Simulation.md
+++ b/connector/doc/Skyline_Spectrum_Simulation.md
@@ -1,8 +1,8 @@
 ---
-uid: Connector_help_Skyline_Spectrum_Simulator
+uid: Connector_help_Skyline_Spectrum_Simulation
 ---
 
-# Skyline Spectrum Simulator
+# Skyline Spectrum Simulation
 
 This connector is used to simulate a spectrum analyzer. It allows you to test DataMiner Spectrum Analysis without the need for an actual device or special debug code directly in SLSpectrum.
 
@@ -12,7 +12,7 @@ This connector is used to simulate a spectrum analyzer. It allows you to test Da
 
 | Range              | Key Features     | Based on     | System Impact     |
 |--------------------|------------------|--------------|-------------------|
-| 1.0.0.x [SLC Main] | Initial version  | -            | -                |
+| 1.0.0.x [SLC Main] | Initial version  | -            | -                 |
 
 ### Product Info
 
@@ -48,9 +48,9 @@ This page contains general information, as well as the following parameters:
 
   - The *Center Trace Pattern* mode creates a waveform at the center of the spectrum analyzer trace. The type of waveform is based on the value of the Trace Pattern parameter.
 
-  - The *Carriers from Table* mode creates a waveform based on the Center Frequency, Bandwidth, and Amplitude specified in the Carrier Table.
+  - The *Carriers from Table* mode creates a waveform based on the Center Frequency, Bandwidth, and Amplitude specified in the **Carrier Table**.
 
-- **Trace pattern**: Allows you to select a specific trace pattern instead of the default pattern. The following patterns are available:
+- **Trace Pattern**: Allows you to select a specific trace pattern instead of the default pattern. The following patterns are available:
 
   - *Default*: A single flat line at the center of the trace window, simulating no available signals or carriers.
 
@@ -62,11 +62,13 @@ This page contains general information, as well as the following parameters:
 
   - *Band*: A set of 8 spikes spread over the trace window, simulating a band with several channels.
 
-- **Floor**: A single line in the lower part of the trace window, simulating no available signals or carriers.
+  - *Floor*: A single line in the lower part of the trace window, simulating no available signals or carriers.
+
+  - *Frequencydependent*: An asymmetrical trace with five carriers, spread over the trace window, which have a different bandwidth but all have the same amplitude.
 
 - **Noise**: Allows you to disable noise in the simulated pattern.
 
-- **Noise depth**: Allows you to modify the amount of random noise added to the simulated pattern, so that you can for instance simulate environments with poor reception.
+- **Noise Depth**: Allows you to modify the amount of random noise added to the simulated pattern, so that you can for instance simulate environments with poor reception.
 
 ### Tracking
 

--- a/connector/toc.yml
+++ b/connector/toc.yml
@@ -7846,8 +7846,8 @@
     topicUid: Connector_help_Skyline_Smart_Serial_Client_Example
   - name: Skyline Smart Serial Server Example
     topicUid: Connector_help_Skyline_Smart_Serial_Server_Example
-  - name: Skyline Spectrum Simulator
-    topicUid: Connector_help_Skyline_Spectrum_Simulator
+  - name: Skyline Spectrum Simulation
+    topicUid: Connector_help_Skyline_Spectrum_Simulation
   - name: Skyline Software Panel
     topicUid: Connector_help_Skyline_Software_Panel
   - name: Skyline SRM Generic Function Generator


### PR DESCRIPTION
This change moves the information from https://docs.dataminer.services/user-guide/Reference/DataMiner_Tools/Spectrum_Simulation_Tool.html to the connector help.