### PR TITLE
connector name correction

### DIFF
--- a/connector/doc/GatesAir_MSCx_1P1_Main_Alt_Controller.md
+++ b/connector/doc/GatesAir_MSCx_1P1_Main_Alt_Controller.md
@@ -1,10 +1,10 @@
 ---
-uid: Connector_help_GatesAir_MCSx_1P1_Main_Alt_Controller
+uid: Connector_help_GatesAir_MSCx_1P1_Main_Alt_Controller
 ---
 
-# GatesAir MCSx 1P1 Main Alt Controller
+# GatesAir MSCx 1P1 Main Alt Controller
 
-The GatesAir MCSx 1P1 Main Alt Controller is designed for seamless broadcast transmission control, with redundancy to ensure uninterrupted operation.
+The GatesAir MSCx 1P1 Main Alt Controller is designed for seamless broadcast transmission control, with redundancy to ensure uninterrupted operation.
 
 ## About
 

--- a/connector/toc.yml
+++ b/connector/toc.yml
@@ -3756,8 +3756,8 @@
     topicUid: Connector_help_GatesAir_Maxiva_XTE_MSC3
   - name: GatesAir Maxiva XTE Transmitter
     topicUid: Connector_help_GatesAir_Maxiva_XTE_Transmitter
-  - name: GatesAir MCSx 1P1 Main Alt Controller
-    topicUid: Connector_help_GatesAir_MCSx_1P1_Main_Alt_Controller
+  - name: GatesAir MSCx 1P1 Main Alt Controller
+    topicUid: Connector_help_GatesAir_MSCx_1P1_Main_Alt_Controller
   - name: GatesAir MSCx DD Dual Drive Controller
     topicUid: Connector_help_GatesAir_MSCx_DD_Dual_Drive_Controller
 - name: Geist


### PR DESCRIPTION
GatesAir MCSx 1P1 Main Alt Controller has been renamed to GatesAir MSCx 1P1 Main Alt Controller