### PR TITLE
Fix casing issues on Siselectron SR1 

### DIFF
--- a/connector/doc/Siselectron_SR1.md
+++ b/connector/doc/Siselectron_SR1.md
@@ -1,5 +1,5 @@
 ---
-uid: Connector_help_SISELECTRON_SR1
+uid: Connector_help_Siselectron_SR1
 ---
 
 # Siselectron SR1

--- a/connector/doc/Siselectron_SR1.md
+++ b/connector/doc/Siselectron_SR1.md
@@ -32,4 +32,4 @@ This is a DataMiner connector for the **Siselectron SR1**, a rack mount server t
 ## Technical Information
 
 > [!NOTE]
-> For detailed technical information, refer to our [technical documentation](xref:Connector_help_SISELECTRON_SR1_Technical).
+> For detailed technical information, refer to our [technical documentation](xref:Connector_help_Siselectron_SR1_Technical).

--- a/connector/doc/Siselectron_SR1_Technical.md
+++ b/connector/doc/Siselectron_SR1_Technical.md
@@ -1,5 +1,5 @@
 ---
-uid: Connector_help_SISELECTRON_SR1_Technical
+uid: Connector_help_Siselectron_SR1_Technical
 ---
 
 # Siselectron SR1

--- a/connector/toc.yml
+++ b/connector/toc.yml
@@ -7844,10 +7844,10 @@
 - name: Siselectron
   items:
   - name: Siselectron SR1
-    topicUid: Connector_help_SISELECTRON_SR1
+    topicUid: Connector_help_Siselectron_SR1
     items:
     - name: Siselectron SR1 Technical
-      topicUid: Connector_help_SISELECTRON_SR1_Technical
+      topicUid: Connector_help_Siselectron_SR1_Technical
 - name: Sittig
   items:
   - name: Sittig DVA


### PR DESCRIPTION
I found that the Siselectron SR1 documentation isn't appearing on Catalog which seems to be based on strict casing. I fixed this for both documentations. 