### PR TITLE
Added new Doc page for Site Sentinel

### DIFF
--- a/.github/workflows/azure-static-web-apps-happy-dune-071cbee03.yml
+++ b/.github/workflows/azure-static-web-apps-happy-dune-071cbee03.yml
@@ -35,6 +35,33 @@ jobs:
           name: release
           path: _site.zip
           
+  deploy_job:
+    if: (github.event_name == 'push' && github.repository == 'SkylineCommunications/dataminer-docs-connectors')
+    runs-on: ubuntu-latest
+    needs: build_job
+    name: Deploy Job
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release
+          path: .
+      - name: Unzip artifact for deployment
+        run: Expand-Archive -Path _site.zip -DestinationPath ./_site
+        shell: pwsh
+      - name: Build And Deploy
+        id: builddeploy
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_HAPPY_DUNE_071CBEE03 }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
+          action: "upload"
+          ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
+          # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
+          app_location: "/_site" # App source code path
+          api_location: "" # Api source code path - optional
+          output_location: "" # Built app content directory - optional
+          ###### End of Repository/Build Configurations ######
+
   deploy_job_SA_SWA_connectordocs:
     if: (github.event_name == 'push' && github.repository == 'SkylineCommunications/dataminer-docs-connectors')
     runs-on: ubuntu-latest

--- a/.github/workflows/azure-static-web-apps-happy-dune-071cbee03.yml
+++ b/.github/workflows/azure-static-web-apps-happy-dune-071cbee03.yml
@@ -35,33 +35,6 @@ jobs:
           name: release
           path: _site.zip
           
-  deploy_job:
-    if: (github.event_name == 'push' && github.repository == 'SkylineCommunications/dataminer-docs-connectors')
-    runs-on: ubuntu-latest
-    needs: build_job
-    name: Deploy Job
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: release
-          path: .
-      - name: Unzip artifact for deployment
-        run: Expand-Archive -Path _site.zip -DestinationPath ./_site
-        shell: pwsh
-      - name: Build And Deploy
-        id: builddeploy
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_HAPPY_DUNE_071CBEE03 }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
-          action: "upload"
-          ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
-          # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_location: "/_site" # App source code path
-          api_location: "" # Api source code path - optional
-          output_location: "" # Built app content directory - optional
-          ###### End of Repository/Build Configurations ######
-
   deploy_job_SA_SWA_connectordocs:
     if: (github.event_name == 'push' && github.repository == 'SkylineCommunications/dataminer-docs-connectors')
     runs-on: ubuntu-latest

--- a/connector/doc/Broadcast_Tools_Site_Sentinel.md
+++ b/connector/doc/Broadcast_Tools_Site_Sentinel.md
@@ -4,31 +4,22 @@ uid: Connector_help_Site_Sentinel
 
 # About
 
-The Site Sentinel® 16 G2 is a robust, full-featured, web-enabled sixteen channel remote control featuring a desktop/mobile browser compatible web interface (HTML5.) The system is equipped with 16 metering inputs (0 to 10 VDC), four virtual metering channels, 16 optically-isolated status (logic) inputs, 33 programmable SPDT relays which may be configured for ON, OFF and pulsed operation, four temperature probe inputs, one internal temperature sensor, stereo silence sensor, and power failure input. Includes built-in support for email alarms and SNMP.
+The Site Sentinel® 16 G2 is a robust, full-featured, web-enabled sixteen-channel remote control featuring a desktop/mobile browser-compatible web interface (HTML5.) The system is equipped with 16 metering inputs (0 to 10 VDC), four virtual metering channels, 16 optically isolated status (logic) inputs, 33 programmable SPDT relays, which may be configured for ON, OFF, and pulsed operation, four temperature probe inputs, one internal temperature sensor, stereo silence sensor, and power failure input. It also includes built-in support for email alarms and SNMP.
 
 ## Key Features
 
-- Monitor and generate DataMiner alarms for the status of relays to improve uptime and reduce downtime for the critical equipment.
-- Remotely configure and control each relay from your DataMiner system to improve operational efficiency.
-- Frequent polling and trap retrieval for updating meter values to ensure fluctuating and out of spec equipment readings generate alarms.
+- Monitor and generate DataMiner alarms for the status of relays to **improve uptime** and reduce downtime of critical equipment.
+- **Remotely configure and control each relay** from your DataMiner System to improve operational efficiency.
+- Frequent polling and trap retrieval for updating meter values to ensure optimal **alarm monitoring of fluctuating and out-of-spec equipment readings**.
 - Chassis temperature and temperature probe monitoring.
 
 ## Use Cases
 
-### Use Case 1
+- From a single pane of glass, aggregate meter values and relay statuses from multiple sites to control and monitor critical equipment located at broadcast facilities, remote sites, data centers, etc. from your DataMiner System.
+- Integrate meter and relay monitoring and control into your existing monitoring workflow via DataMiner Correlation, Automation, Dashboards, Low-Code Apps, and Visual Overview.
+- Use the historical data collection mechanisms within DataMiner to automate the generation of scheduled reports based upon the meter and relay status of various equipment.
 
-- From a single pane of glass, aggregate meter values and relay statuses from multiple sites to control and monitor critical equipment located at Broadcast Facilities, Remote Sites, Data Centers, etc. from your DataMiner system.
+## Technical info
 
-### Use Case 2
-
-- Integrate meter and relay monitoring and control into your existing monitoring workflow via correlation, automation, dashboards, low code apps, and cube visual overviews.
-
-### Use Case 3
-
-- The historical data collection mechanisms within DataMiner allows site operators to automate the generation of required scheduled reports based upon the meter and relay status of various equipment.
-
-## Technical Reference
-
-### Prerequisites
-
-- N/A
+> [!NOTE]
+> For detailed technical information, refer to the [Technical help page](xref:Connector_help_Site_Sentinel_Technical).

--- a/connector/doc/Broadcast_Tools_Site_Sentinel.md
+++ b/connector/doc/Broadcast_Tools_Site_Sentinel.md
@@ -1,3 +1,7 @@
+---
+uid: Connector_help_Site_Sentinel
+---
+
 # About
 
 The Site Sentinel® 16 G2 is a robust, full-featured, web-enabled sixteen channel remote control featuring a desktop/mobile browser compatible web interface (HTML5.) The system is equipped with 16 metering inputs (0 to 10 VDC), four virtual metering channels, 16 optically-isolated status (logic) inputs, 33 programmable SPDT relays which may be configured for ON, OFF and pulsed operation, four temperature probe inputs, one internal temperature sensor, stereo silence sensor, and power failure input. Includes built-in support for email alarms and SNMP.

--- a/connector/doc/Broadcast_Tools_Site_Sentinel.md
+++ b/connector/doc/Broadcast_Tools_Site_Sentinel.md
@@ -1,0 +1,30 @@
+# About
+
+The Site Sentinel® 16 G2 is a robust, full-featured, web-enabled sixteen channel remote control featuring a desktop/mobile browser compatible web interface (HTML5.) The system is equipped with 16 metering inputs (0 to 10 VDC), four virtual metering channels, 16 optically-isolated status (logic) inputs, 33 programmable SPDT relays which may be configured for ON, OFF and pulsed operation, four temperature probe inputs, one internal temperature sensor, stereo silence sensor, and power failure input. Includes built-in support for email alarms and SNMP.
+
+## Key Features
+
+- Monitor and generate DataMiner alarms for the status of relays to improve uptime and reduce downtime for the critical equipment.
+- Remotely configure and control each relay from your DataMiner system to improve operational efficiency.
+- Frequent polling and trap retrieval for updating meter values to ensure fluctuating and out of spec equipment readings generate alarms.
+- Chassis temperature and temperature probe monitoring.
+
+## Use Cases
+
+### Use Case 1
+
+- From a single pane of glass, aggregate meter values and relay statuses from multiple sites to control and monitor critical equipment located at Broadcast Facilities, Remote Sites, Data Centers, etc. from your DataMiner system.
+
+### Use Case 2
+
+- Integrate meter and relay monitoring and control into your existing monitoring workflow via correlation, automation, dashboards, low code apps, and cube visual overviews.
+
+### Use Case 3
+
+- The historical data collection mechanisms within DataMiner allows site operators to automate the generation of required scheduled reports based upon the meter and relay status of various equipment.
+
+## Technical Reference
+
+### Prerequisites
+
+- N/A

--- a/connector/doc/Broadcast_Tools_Site_Sentinel_Technical.md
+++ b/connector/doc/Broadcast_Tools_Site_Sentinel_Technical.md
@@ -1,5 +1,5 @@
 ---
-uid: Connector_help_Broadcast_Tools_Site_Sentinel
+uid: Connector_help_Site_Sentinel_Technical
 ---
 
 # Broadcast Tools Site Sentinel

--- a/connector/doc/Broadcast_Tools_Site_Sentinel_Technical.md
+++ b/connector/doc/Broadcast_Tools_Site_Sentinel_Technical.md
@@ -1,0 +1,64 @@
+---
+uid: Connector_help_Broadcast_Tools_Site_Sentinel
+---
+
+# Broadcast Tools Site Sentinel
+
+The Site Sentinel® 16 G2 is a robust, full-featured, web-enabled sixteen channel remote control featuring a desktop/mobile browser compatible web interface (HTML5.) The system is equipped with 16 metering inputs (0 to 10 VDC), four virtual metering channels, 16 optically-isolated status (logic) inputs, 33 programmable SPDT relays which may be configured for ON, OFF and pulsed operation, four temperature probe inputs, one internal temperature sensor, stereo silence sensor, and power failure input. Includes built-in support for email alarms and SNMP.
+
+## About
+
+### Version Info
+
+|Range  |Features  |Based on  |System Impact  |
+|---------|---------|---------|---------|
+|1.0.0.x [SLC Main]     |<ul><li>Initial version</li></ul>         |-         |-         |
+
+### Product Info
+
+|Range  |Supported Firmware  |
+|---------|---------|
+|1.0.0.x     |       |
+
+### System Info
+
+|Range  |DCF Integration  |Cassandra Compliant  |Linked Components  |Exported Components   |
+|---------|---------|---------|---------|---------|
+|1.0.0.x    |No       |Yes         |-         |   |
+
+## Configuration
+
+### Connections
+
+#### SNMP Connection - Main Connection
+
+This connector uses a Simple Network Management Protocol (SNMP) connection and requires the following input during element creation:
+
+SNMP CONNECTION:
+
+- **IP address/host**: [The polling IP or URL of the destination.]
+- **IP port**: [The IP port of the destination.]
+- **Bus address**: [The bus address of the device.]
+
+SNMP Settings:
+
+- **Get community string**: [The community string used when reading values from the device. (default: *public*)]
+- **Set community string**: [The community string used when setting values on the device. (default: *private*)]
+
+### Initialization
+
+No additional configuration is needed.
+
+### Redundancy
+
+There is no redundancy defined.
+
+### Web Interface
+
+The web interface is only accessible when the client machine has network access to the product.
+
+## How to use
+
+An SNMP connection is used to retrieve all relevant data needed to monitor the Site Sentinel.
+
+The **Meter** table on the **Meters** page contains custom columns (**Calibration Formula**, **Calibration Multiplier**, and **Expected Calculated Value**) that can be used to alter the incoming **Value** from the device. If no alteration is needed, leave the columns with their default values.

--- a/connector/doc/Broadcast_Tools_Site_Sentinel_Technical.md
+++ b/connector/doc/Broadcast_Tools_Site_Sentinel_Technical.md
@@ -4,27 +4,9 @@ uid: Connector_help_Site_Sentinel_Technical
 
 # Broadcast Tools Site Sentinel
 
-The Site Sentinel® 16 G2 is a robust, full-featured, web-enabled sixteen channel remote control featuring a desktop/mobile browser compatible web interface (HTML5.) The system is equipped with 16 metering inputs (0 to 10 VDC), four virtual metering channels, 16 optically-isolated status (logic) inputs, 33 programmable SPDT relays which may be configured for ON, OFF and pulsed operation, four temperature probe inputs, one internal temperature sensor, stereo silence sensor, and power failure input. Includes built-in support for email alarms and SNMP.
-
 ## About
 
-### Version Info
-
-|Range  |Features  |Based on  |System Impact  |
-|---------|---------|---------|---------|
-|1.0.0.x [SLC Main]     |<ul><li>Initial version</li></ul>         |-         |-         |
-
-### Product Info
-
-|Range  |Supported Firmware  |
-|---------|---------|
-|1.0.0.x     |       |
-
-### System Info
-
-|Range  |DCF Integration  |Cassandra Compliant  |Linked Components  |Exported Components   |
-|---------|---------|---------|---------|---------|
-|1.0.0.x    |No       |Yes         |-         |   |
+The Site Sentinel® 16 G2 is a robust, full-featured, web-enabled sixteen-channel remote control featuring a desktop/mobile browser-compatible web interface (HTML5.) The system is equipped with 16 metering inputs (0 to 10 VDC), four virtual metering channels, 16 optically isolated status (logic) inputs, 33 programmable SPDT relays, which may be configured for ON, OFF, and pulsed operation, four temperature probe inputs, one internal temperature sensor, stereo silence sensor, and power failure input. It also includes built-in support for email alarms and SNMP.
 
 ## Configuration
 
@@ -36,22 +18,14 @@ This connector uses a Simple Network Management Protocol (SNMP) connection and r
 
 SNMP CONNECTION:
 
-- **IP address/host**: [The polling IP or URL of the destination.]
-- **IP port**: [The IP port of the destination.]
-- **Bus address**: [The bus address of the device.]
+- **IP address/host**: The polling IP or URL of the destination.
+- **IP port**: The IP port of the destination.
+- **Bus address**: The bus address of the device.
 
 SNMP Settings:
 
-- **Get community string**: [The community string used when reading values from the device. (default: *public*)]
-- **Set community string**: [The community string used when setting values on the device. (default: *private*)]
-
-### Initialization
-
-No additional configuration is needed.
-
-### Redundancy
-
-There is no redundancy defined.
+- **Get community string**: The community string used when reading values from the device (default: *public*).
+- **Set community string**: The community string used when setting values on the device (default: *private*).
 
 ### Web Interface
 
@@ -61,4 +35,4 @@ The web interface is only accessible when the client machine has network access 
 
 An SNMP connection is used to retrieve all relevant data needed to monitor the Site Sentinel.
 
-The **Meter** table on the **Meters** page contains custom columns (**Calibration Formula**, **Calibration Multiplier**, and **Expected Calculated Value**) that can be used to alter the incoming **Value** from the device. If no alteration is needed, leave the columns with their default values.
+The **Meter** table on the **Meters** page contains custom columns (**Calibration Formula**, **Calibration Multiplier**, and **Expected Calculated Value**) that can be used to alter the incoming value from the device. If no alteration is needed, you can leave the columns set to their default values.

--- a/connector/toc.yml
+++ b/connector/toc.yml
@@ -7856,7 +7856,7 @@
 - name: Site Sentinel
   topicUid: Connector_help_Site_Sentinel
   items:
-    - name: Site Sentinel Techincal
+    - name: Site Sentinel Technical
       topicUid: Connector_help_Site_Sentinel_Technical
 - name: Sittig
   items:

--- a/connector/toc.yml
+++ b/connector/toc.yml
@@ -7848,6 +7848,11 @@
     items:
     - name: Siselectron SR1 Technical
       topicUid: Connector_help_SISELECTRON_SR1_Technical
+- name: Site Sentinel
+  topicUid: Connector_help_Site_Sentinel
+  items:
+    - name: Site Sentinel Techincal
+      topicUid: Connector_help_Site_Sentinel_Technical
 - name: Sittig
   items:
   - name: Sittig DVA


### PR DESCRIPTION
This pull request includes several changes to the `SkylineCommunications/dataminer-docs-connectors` repository. The most important changes include adding documentation for the Broadcast Tools Site Sentinel connector, and updating the table of contents to include the new documentation.

### Documentation additions:
* [`connector/doc/Broadcast_Tools_Site_Sentinel.md`](diffhunk://#diff-74d9f8513376b3c3a3cc62addca9301cf6526482f7c7549acb1b12664acef7d5R1-R30): Added new documentation outlining the features, use cases, and technical references for the Broadcast Tools Site Sentinel.
* [`connector/doc/Broadcast_Tools_Site_Sentinel_Technical.md`](diffhunk://#diff-f7edcdd3646e673cbfc2f8d3b5a86e448a8d6c4abb724cd34279aea6f3481bebR1-R64): Added a technical guide for the Broadcast Tools Site Sentinel, including version info, product info, system info, configuration details, and usage instructions.

### Table of contents update:
* [`connector/toc.yml`](diffhunk://#diff-e96a16790f2c239c336b059ca4672fb64b82e3a0e4b795dfbab684ce4ffaff6aR7851-R7855): Updated the table of contents to include entries for the new Broadcast Tools Site Sentinel documentation.