### PR TITLE
Added correct vendor name to site sentinel

### DIFF
--- a/connector/doc/Broadcast_Tools_Site_Sentinel.md
+++ b/connector/doc/Broadcast_Tools_Site_Sentinel.md
@@ -22,4 +22,4 @@ The Site Sentinel® 16 G2 is a robust, full-featured, web-enabled sixteen-channe
 ## Technical info
 
 > [!NOTE]
-> For detailed technical information, refer to the [Technical help page](xref:Connector_help_Site_Sentinel_Technical).
+> For detailed technical information, refer to the [Technical help page](xref:Connector_help_Broadcast_Tools_Site_Sentinel_Technical).

--- a/connector/doc/Broadcast_Tools_Site_Sentinel.md
+++ b/connector/doc/Broadcast_Tools_Site_Sentinel.md
@@ -2,7 +2,9 @@
 uid: Connector_help_Broadcast_Tools_Site_Sentinel
 ---
 
-# About
+# Broadcast Tools Site Sentinel
+
+## About
 
 The Site Sentinel® 16 G2 is a robust, full-featured, web-enabled sixteen-channel remote control featuring a desktop/mobile browser-compatible web interface (HTML5.) The system is equipped with 16 metering inputs (0 to 10 VDC), four virtual metering channels, 16 optically isolated status (logic) inputs, 33 programmable SPDT relays, which may be configured for ON, OFF, and pulsed operation, four temperature probe inputs, one internal temperature sensor, stereo silence sensor, and power failure input. It also includes built-in support for email alarms and SNMP.
 

--- a/connector/doc/Broadcast_Tools_Site_Sentinel.md
+++ b/connector/doc/Broadcast_Tools_Site_Sentinel.md
@@ -1,5 +1,5 @@
 ---
-uid: Connector_help_Site_Sentinel
+uid: Connector_help_Broadcast_Tools_Site_Sentinel
 ---
 
 # About

--- a/connector/doc/Broadcast_Tools_Site_Sentinel_Technical.md
+++ b/connector/doc/Broadcast_Tools_Site_Sentinel_Technical.md
@@ -1,5 +1,5 @@
 ---
-uid: Connector_help_Site_Sentinel_Technical
+uid: Connector_help_Broadcast_Tools_Site_Sentinel_Technical
 ---
 
 # Broadcast Tools Site Sentinel

--- a/connector/toc.yml
+++ b/connector/toc.yml
@@ -1740,6 +1740,11 @@
   items:
   - name: Broadcast Automation Systems Equinox TS
     topicUid: Connector_help_Broadcast_Automation_Systems_Equinox_TS
+- name: Broadcast Tools Site Sentinel
+  topicUid: Connector_help_Broadcast_Tools_Site_Sentinel
+  items:
+    - name: Broadcast Tools Site Sentinel Technical
+      topicUid: Connector_help_Broadcast_Tools_Site_Sentinel_Technical
 - name: BroadForward
   items:
   - name: BroadForward ENUM NP
@@ -7860,11 +7865,6 @@
     items:
     - name: Siselectron SR1 Technical
       topicUid: Connector_help_Siselectron_SR1_Technical
-- name: Site Sentinel
-  topicUid: Connector_help_Site_Sentinel
-  items:
-    - name: Site Sentinel Technical
-      topicUid: Connector_help_Site_Sentinel_Technical
 - name: Sittig
   items:
   - name: Sittig DVA


### PR DESCRIPTION
This pull request includes changes to update documentation and the table of contents for the Broadcast Tools Site Sentinel. The most important changes include updating the `uid` values in the documentation files and reorganizing the entries in the table of contents.

Documentation updates:

* [`connector/doc/Broadcast_Tools_Site_Sentinel.md`](diffhunk://#diff-74d9f8513376b3c3a3cc62addca9301cf6526482f7c7549acb1b12664acef7d5L2-R2): Updated `uid` to `Connector_help_Broadcast_Tools_Site_Sentinel`.
* [`connector/doc/Broadcast_Tools_Site_Sentinel_Technical.md`](diffhunk://#diff-f7edcdd3646e673cbfc2f8d3b5a86e448a8d6c4abb724cd34279aea6f3481bebL2-R2): Updated `uid` to `Connector_help_Broadcast_Tools_Site_Sentinel_Technical`.

Table of contents reorganization:

* [`connector/toc.yml`](diffhunk://#diff-e96a16790f2c239c336b059ca4672fb64b82e3a0e4b795dfbab684ce4ffaff6aR1743-R1747): Added new entries for Broadcast Tools Site Sentinel and its technical documentation.
* [`connector/toc.yml`](diffhunk://#diff-e96a16790f2c239c336b059ca4672fb64b82e3a0e4b795dfbab684ce4ffaff6aL7863-L7867): Removed old entries for Site Sentinel and its technical documentation.