### PR TITLE
Update CISCO_APIC_Technical.md

### DIFF
--- a/connector/doc/CISCO_APIC_Technical.md
+++ b/connector/doc/CISCO_APIC_Technical.md
@@ -44,7 +44,7 @@ The element created with this connector consists of the following data pages:
 
 - **CPU**: Displays the **CPUs** table.
 
-  Note that the polled SNMP index is not saved over reboots for the CISCO APIC. Because of this limitation in the software, alarm and trend info will be removed when a reboot on the CISCO APIC is detected. This is done to prevent a mismatch in trending and alarming.
+  Note that the polled SNMP index is not saved over reboots for the CISCO APIC. Because of this limitation in the software, the same primary key might not necessarily refer to the same cpu, resulting in a possible mismatch in alarming/trending.
 
 - **Power**: Displays power related physical entities.
 

--- a/connector/doc/CISCO_APIC_Technical.md
+++ b/connector/doc/CISCO_APIC_Technical.md
@@ -44,7 +44,7 @@ The element created with this connector consists of the following data pages:
 
 - **CPU**: Displays the **CPUs** table.
 
-  Note that the polled SNMP index is not saved over reboots for the CISCO APIC. Because of this limitation in the software, the same primary key might not necessarily refer to the same cpu, resulting in a possible mismatch in alarming/trending.
+  Note that the polled SNMP index is not saved over reboots for the CISCO APIC. Because of this limitation in the software, the same primary key might not necessarily refer to the same CPU, resulting in a possible mismatch in alarming/trending.
 
 - **Power**: Displays power related physical entities.
 


### PR DESCRIPTION
Alarm and trend info will no longer be removed upon rebooting the CISCO APIC.
Even though the subtext mentions that the snmp indexes are not saved over reboots, I was not able to verify the behaviour of the CPUs table due to customer constraints. As a result, it was discussed internally that we will only apply the fix if the problem is indeed verified.