### PR TITLE
Update Imagine_Communications_Nexio+_AMP.md

### DIFF
--- a/connector/doc/Imagine_Communications_Nexio+_AMP.md
+++ b/connector/doc/Imagine_Communications_Nexio+_AMP.md
@@ -4,31 +4,23 @@ uid: Connector_help_Imagine_Communications_Nexio+_AMP
 
 # Imagine Communications Nexio+ AMP
 
-This protocol is meant to work with the Imagine Communications Nexio+ AMP video server. The protocol shows basic information of the different communication methods and connections the device is currently using.
-
 ## About
 
-Nexio+T AMPr is the next step in the evolution of the acclaimed Nexio AMPr video server. Now combining industry-leading Hewlett Packard Enterprise standard server models and Imagine software/hardware bundle kits, Nexio+ AMP truly enables software-defined applications and delivers the exceptional reliability, flexibility and format transparency that broadcast operations demand. The Nexio+ AMP Advanced Media Platform is an efficient and integrated server platform for managing digital content from ingest to playout.
+The Nexio+ AMP video server combines Hewlett Packard Enterprise standard server models and Imagine software/hardware bundle kits, enabling software-defined applications and allowing broadcast operations to reliably and flexibly manage digital content from ingest to playout.
+
+This connector is meant to work with the Imagine Communications Nexio+ AMP video server. The connector shows basic information of the different communication methods and connections the device is currently using.
 
 ### Version Info
 
-| Range | Description | DCF Integration | Cassandra Compliant |
-|------------------|-----------------|---------------------|-------------------------|
-| 1.0.0.x (Obsolete)          | Initial Version | No                  | True                    |
-| 1.0.1.x (Obsolete)          |                 | No                  | True                    |
-| 1.1.0.x (SLC Main)          | Firmware change | No                  | True                    |
+| Range              | Description     | DCF Integration | Cassandra Compliant |
+|--------------------|-----------------|-----------------|---------------------|
+| 1.0.0.x (Obsolete) | Initial version | No              | Yes                 |
+| 1.0.1.x (Obsolete) |                 | No              | Yes                 |
+| 1.1.0.x (SLC Main) | Firmware change | No              | Yes                 |
 
-### Product Info
+## Configuration
 
-| Range | Supported Firmware Version |
-|------------------|-----------------------------|
-| 1.0.0.x          | Unknown                     |
-| 1.0.1.x          | Unknown                     |
-| 1.1.0.x          | Unknown                     |
-
-## Installation and configuration
-
-### Creation
+### Connections
 
 #### SNMP Main Connection
 

--- a/connector/doc/Imagine_Communications_Nexio+_AMP.md
+++ b/connector/doc/Imagine_Communications_Nexio+_AMP.md
@@ -4,7 +4,7 @@ uid: Connector_help_Imagine_Communications_Nexio+_AMP
 
 # Imagine Communications Nexio+ AMP
 
-This protol is meant to work with the Imagine Communications Nexio+ AMP video server. The protocol shows basic information of the different communcation methods and connections the device is currently using.
+This protocol is meant to work with the Imagine Communications Nexio+ AMP video server. The protocol shows basic information of the different communication methods and connections the device is currently using.
 
 ## About
 
@@ -14,13 +14,17 @@ Nexio+T AMPr is the next step in the evolution of the acclaimed Nexio AMPr video
 
 | Range | Description | DCF Integration | Cassandra Compliant |
 |------------------|-----------------|---------------------|-------------------------|
-| 1.0.0.x          | Initial Version | No                  | True                    |
+| 1.0.0.x (Obsolete)          | Initial Version | No                  | True                    |
+| 1.0.1.x (Obsolete)          |                 | No                  | True                    |
+| 1.1.0.x (SLC Main)          | Firmware change | No                  | True                    |
 
 ### Product Info
 
 | Range | Supported Firmware Version |
 |------------------|-----------------------------|
 | 1.0.0.x          | Unknown                     |
+| 1.0.1.x          | Unknown                     |
+| 1.1.0.x          | Unknown                     |
 
 ## Installation and configuration
 
@@ -42,23 +46,23 @@ The Interface Table shows the different interfaces that the device is connected 
 
 ### IP Status
 
-This pages shows information on the IP protocol communcation traffic to and from the device. This includes tables showing the connection addresses, the different routes, and the translations.
+This pages shows information on the IP protocol communication traffic to and from the device. This includes tables showing the connection addresses, the different routes, and the translations.
 
 ### ICMP Status
 
-This pages shows information on the ICMP protocol communcation traffic to and from the device.
+This pages shows information on the ICMP protocol communication traffic to and from the device.
 
 ### TCP Status
 
-This pages shows information on the TCP protocol communcation traffic to and from the device. This includes a table showing the different TCP connections.
+This pages shows information on the TCP protocol communication traffic to and from the device. This includes a table showing the different TCP connections.
 
 ### UDP Status
 
-This pages shows information on the UDP protocol communcation traffic to and from the device. This includes a table showing the UDP listeners.
+This pages shows information on the UDP protocol communication traffic to and from the device. This includes a table showing the UDP listeners.
 
 ### SNMP Status
 
-This pages shows information on the SNMP protocol communcation traffic to and from the device.
+This pages shows information on the SNMP protocol communication traffic to and from the device.
 
 ### Server Info
 


### PR DESCRIPTION
This pull request makes updates to the documentation for the Imagine Communications Nexio+ AMP connector. The changes include fixing typos, improving clarity, and updating product version information.

### Documentation improvements:

* Corrected multiple instances of the word "communcation" to "communication" in descriptions of protocol traffic across various sections (`IP Status`, `ICMP Status`, `TCP Status`, `UDP Status`, and `SNMP Status`). [[1]](diffhunk://#diff-64a6e3580f3d2d782f28aa90c27686504a4dd7c38e6006b0706b5c895c25a3bbL7-R7) [[2]](diffhunk://#diff-64a6e3580f3d2d782f28aa90c27686504a4dd7c38e6006b0706b5c895c25a3bbL45-R65)

* Updated the product version table to include new firmware versions (`1.0.1.x` and `1.1.0.x`) and marked older versions (`1.0.0.x` and `1.0.1.x`) as obsolete.