### PR TITLE
markdown rendering issue on Bridge Technologies VB220

### DIFF
--- a/connector/doc/Bridge_Technologies_VB220.md
+++ b/connector/doc/Bridge_Technologies_VB220.md
@@ -5,6 +5,7 @@ uid: Connector_help_Bridge_Technologies_VB220
 # Bridge Technologies VB220
 
 > [!IMPORTANT]
+> 
 > This connector is no longer supported by Skyline.
 >
 > - Does your probe use hardware **version 4 or higher**? Use [Bridge Technologies VB Probe Series](https://catalog.dataminer.services/details/f1fa63a6-62b8-4817-82b6-7f37efb7371f).


### PR DESCRIPTION
Apparently Catalog currently requires an empty line between the IMPORTANT and the content for it to be properly rendered.
As far as I know, markdown does support it without the empty line, right?
I'm adding the empty line for now as a workaround in the meantime but on the long run, we should:
- either have Catalog changed so it supports it without such empty line.
- either have DM Docs updated so examples do have the extra empty lines: https://docs.dataminer.services/contributing/CTB_Markdown_Syntax.html#alerts