### PR TITLE
Updated documentation for Pro-Bel SW-P-08

### DIFF
--- a/connector/doc/Pro-Bel_SW-P-08.md
+++ b/connector/doc/Pro-Bel_SW-P-08.md
@@ -10,29 +10,34 @@ The Pro-Bel SW-P-08 connector can be used to monitor and control any router that
 
 ## Key Features
 
-- **Monitoring crosspoints**: Provides an overview of current crosspoint connections in form of Sources and Destinations.
+- **Monitoring crosspoints**: Provides an overview of current crosspoint connections in the form of sources and destinations.
 
-- **Crosspoint management**: Supports setting the crosspoints, allowing the management of connections.
+- **Crosspoint management**: Allows you to manage connections by setting crosspoints.
 
-- **Extended support**: Supports use of extended commands, making it easy to utilize routers of any size.
+- **Extended support**: Supports the use of extended commands, making it easy to utilize routers of any size.
 
-### Use Case 1
+### Use Case
 
 **Challenge**: Managing routers from different vendors.
 
-**Solution**: Create a dedicated element in DataMiner for all of your routers.
+**Solution**: Create a dedicated element in DataMiner for all your routers.
 
-**Benefit**: Pro-Bel SW-P-08's implementation of generic remote control protocol allows user to interact with wide variety of devices, free from limitations of any specific vendor. On top of that, because protocol is implemented at the lowest possible level, the communication is guaranteed to be fast, responsive and light-weight, ensuring smooth operations and easy management of all of your routers.
+**Benefit**: Pro-Bel SW-P-08's implementation of generic remote control protocol allows you to interact with wide variety of devices, free from limitations of any specific vendor. On top of that, because the protocol is implemented at the lowest possible level, the communication is guaranteed to be fast, responsive and lightweight, ensuring smooth operations and easy management of all of your routers.
+
+## Prerequisites
+
+The minimum required DataMiner version for range 2.0.0.x of this connector is **10.3.0**.
 
 ## Technical Reference
 
-In order to improve the performance, reliability and to future-proof the connector we are currently in the process of moving to range 2.0.0.X. As this is work in progress not all features available on the previous range are yet implemented in the new one. 
+This connector has two ranges: 1.0.0.x and 2.0.0.x. The 2.0.0.x range is currently still being developed. It will improve the performance and reliability of the connector and make it more future-proof. However, not all features from the 1.0.0.x range are currently already available in the 2.0.0.x range.
 
-Features that are only available in the previous range are:
+At present, the following features are only available in the 1.0.0.x range:
+
 - Matrix view of crosspoints
 - DCF support
 - CSV label import/export
 - Dual controller
 
 > [!NOTE]
-> For detailed technical information, refer to our [technical documentation](xref:Connector_technical_Pro-Bel_SW-P-08_2.0.0.X). For previous range refer to [technical documentation(1.0.0.X)](xref:Connector_technical_Pro-Bel_SW-P-08_1.0.0.X)
+> For detailed technical information about the 2.0.0.x range, refer to our [technical documentation (2.0.0.x)](xref:Connector_technical_Pro-Bel_SW-P-08_2.0.0.X). For the 1.0.0.x range, refer to the [technical documentation (1.0.0.x)](xref:Connector_technical_Pro-Bel_SW-P-08_1.0.0.X).

--- a/connector/doc/Pro-Bel_SW-P-08_Technical_1.0.0.X.md
+++ b/connector/doc/Pro-Bel_SW-P-08_Technical_1.0.0.X.md
@@ -4,9 +4,9 @@ uid: Connector_technical_Pro-Bel_SW-P-08_1.0.0.X
 
 # Pro-Bel SW-P-08 (1.0.0.X)
 
-The Pro-Bel SW-P-08 connector provides an interface to set or remove connections in the output routing of a controlled device from remote devices. It can be used to monitor and control any router that supports the Pro-Bel SW-P-08 protocol. A serial connection is used in order to successfully retrieve and configure the matrix. A matrix is used in order to easily connect a destination with a source.
-
 ## About
+
+The Pro-Bel SW-P-08 connector provides an interface to set or remove connections in the output routing of a controlled device from remote devices. It can be used to monitor and control any router that supports the Pro-Bel SW-P-08 protocol. A serial connection is used in order to successfully retrieve and configure the matrix. A matrix is used in order to easily connect a destination with a source.
 
 ### Version Info
 
@@ -18,17 +18,6 @@ The Pro-Bel SW-P-08 connector provides an interface to set or remove connections
 | 1.0.3.x            | Reviewed connector. Implemented latest Matrix Community Class.      | -        | -                                           |
 | 1.0.4.x            | Additional functionality added.                                     | -        | -                                           |
 | 1.0.5.x            | Dual Controller functionality implemented.                          | -        | Minimum required version: 10.3.11.0 - 13456 |
-
-### Product Info
-
-| Range     | Supported Firmware     |
-|-----------|------------------------|
-| 1.0.0.x   | -                      |
-| 1.0.1.x   | -                      |
-| 1.0.2.x   | -                      |
-| 1.0.3.x   | -                      |
-| 1.0.4.x   | -                      |
-| 1.0.5.x   | -                      |
 
 ### System Info
 
@@ -65,9 +54,9 @@ SERIAL CONNECTION:
   - **IP port**: The IP port of the device.
   - **Bus address**: The "Matrix Number", "Level Number", "Number of Inputs", and "Number of Outputs" of the matrix, separated by a period ("."). The range of inputs and outputs is 1-1024. For instance: "*1024.1024*".
 
-## Usage
+## How to Use
 
-The element consists of the following pages: **Matrix**, **General**, **Inputs/Outputs** and **Labels**.
+The element consists of the following pages: **Matrix**, **General**, **Inputs/Outputs**, and **Labels**.
 
 ### Matrix
 

--- a/connector/doc/Pro-Bel_SW-P-08_Technical_2.0.0.X.md
+++ b/connector/doc/Pro-Bel_SW-P-08_Technical_2.0.0.X.md
@@ -6,13 +6,13 @@ uid: Connector_technical_Pro-Bel_SW-P-08_2.0.0.X
 
 ## About
 
-Pro-Bel SW-P-08 is used to communicate with routers that implement general remote control protocol SW-P-08. It allows management and monitoring of the crosspoints.
+Pro-Bel SW-P-08 is used to communicate with routers that implement general remote control protocol SW-P-08. It allows management and monitoring of crosspoints.
 
 ## Configuration
 
 ### Connections
 
-#### Smart-Serial connection
+#### Smart-Serial Connection
 
 This connector uses a smart-serial connection and requires the following input during element creation:
 
@@ -24,12 +24,13 @@ SERIAL CONNECTION:
   - **IP port**: The IP port of the device.
   - **Accepted IP address**: The IP of the device from which to accept messages.
 
-The following are defined by the protocol documentation and are set as defaults:
-  - **Baudrate**: Baudrate specified in the documentation (default: 9600).
-  - **Databits**: Databits specified in the documentation (default: 8).
-  - **Stopbits**: Stopbits specified in the documentation (default: 1).
-  - **Parity**: Parity specified in the documentation (default: No).
-  - **FlowControl**: FlowControl specified in the documentation (default: No).
+The following values are defined by the protocol documentation and are set as defaults:
+
+- **Baudrate**: Baudrate specified in the documentation (default: *9600*).
+- **Databits**: Databits specified in the documentation (default: *8*).
+- **Stopbits**: Stopbits specified in the documentation (default: *1*).
+- **Parity**: Parity specified in the documentation (default: *No*).
+- **FlowControl**: FlowControl specified in the documentation (default: *No*).
 
 ## How to Use
 
@@ -53,4 +54,4 @@ This page contains the **Sources** and **Destinations** tables, which contain in
 
 ## Notes
 
-Minimum required DataMiner version for the connector is **10.3.0.0 - 12752**.
+The minimum required DataMiner version for this connector is **10.3.0**.

--- a/connector/toc.yml
+++ b/connector/toc.yml
@@ -7599,9 +7599,9 @@
   - name: Pro-Bel SW-P-08
     topicUid: Connector_help_Pro-Bel_SW-P-08
     items: 
-    - name: Pro-Bel SW-P-08(2.0.0.X)
+    - name: Pro-Bel SW-P-08 Technical (2.0.0.x)
       topicUid: Connector_technical_Pro-Bel_SW-P-08_2.0.0.X
-    - name: Pro-Bel SW-P-08(1.0.0.X)
+    - name: Pro-Bel SW-P-08 Technical (1.0.0.x)
       topicUid: Connector_technical_Pro-Bel_SW-P-08_1.0.0.X
 - name: Prodys
   items:


### PR DESCRIPTION
Range 1.0.0.X will be deprecated in the future and new clients are encouraged to use new range because 1.0.0.X will receive only limited and customer specific support, so I didn't put too much effort in writing it's documentation up to new standards as it will become obsolete.