### PR TITLE
Add numericValue to supported alarm properties

### DIFF
--- a/connector/doc/Generic_Webhook_Alarm_Table.md
+++ b/connector/doc/Generic_Webhook_Alarm_Table.md
@@ -63,7 +63,6 @@ This is an example JSON message:
 "Property7": "Fubar",
 "Property8": "test",
 "Property9": "yes",
-
 "Property10": "Fubar",
 "Property11": "Some Machine",
 "Property12": "Network is down",


### PR DESCRIPTION
Added 'numericValue' property to the supported alarm properties and updated the example JSON message accordingly.