### PR TITLE
Create documentation for STX LP GEN II connector

### DIFF
--- a/connector/doc/Broadcast_Electronics_STX_LP_GEN_II.md
+++ b/connector/doc/Broadcast_Electronics_STX_LP_GEN_II.md
@@ -21,4 +21,3 @@ The Broadcast Electronics STX LP GEN II is designed for continuous monitoring. W
 
 > [!NOTE]
 > For detailed technical information, refer to our [technical documentation](xref:Connector_help_Broadcast_Electronics_STX_LP_GEN_II_Technical).
-

--- a/connector/doc/Broadcast_Electronics_STX_LP_GEN_II_Technical.md
+++ b/connector/doc/Broadcast_Electronics_STX_LP_GEN_II_Technical.md
@@ -1,0 +1,41 @@
+---
+uid: Connector_help_Broadcast_Electronics_STX_LP_GEN_II_Technical
+---
+
+# Broadcast Electronics STX LP GEN II
+
+## About
+
+The STX LP Generation II is a compact, low-power FM transmitter series (available in 1, 2, 3, and 5 kW models), engineered by Broadcast Electronics for professional broadcasting environments
+
+## Configuration
+
+### Connections
+
+#### SNMP Connection
+
+This connector uses a Simple Network Management Protocol (SNMP) connection and requires the following input during element creation:
+
+SNMP CONNECTION:
+
+- **IP address/host**: The polling IP or URL of the destination.
+- **IP port**: The IP port of the destination.
+- **Bus address**: The bus address of the device.
+
+SNMP Settings:
+
+- **Get community string**: The community string used when reading values from the device (default: *public*).
+- **Set community string**: The community string used when setting values on the device (default: *private*).
+
+### Web Interface
+
+The web interface is only accessible when the client machine has network access to the product.
+
+## How to use
+
+The element has the following data pages:
+
+- **General**: Displays the device information.
+- **Transmitter**: Displays the transmitter information.
+- **Power Amplifier**: Displays the power amplifier information.
+- **Logs**: Displays the latest events.

--- a/connector/toc.yml
+++ b/connector/toc.yml
@@ -1873,6 +1873,13 @@
   items:
   - name: Broadcast Automation Systems Equinox TS
     topicUid: Connector_help_Broadcast_Automation_Systems_Equinox_TS
+- name: Broadcast Electronics
+  items:
+  - name: Broadcast Electronics STX LP GEN II
+    topicUid: Connector_help_Broadcast_Electronics_STX_LP_GEN_II
+    items:
+    - name: Broadcast Electronics STX LP GEN II Technical
+      topicUid: Connector_help_Broadcast_Electronics_STX_LP_GEN_II_Technical
 - name: Broadcast Tools Site Sentinel
   topicUid: Connector_help_Broadcast_Tools_Site_Sentinel
   items:


### PR DESCRIPTION
Added documentation for Broadcast Electronics STX LP GEN II connector, including features and prerequisites.