### PR TITLE
EVS Neuron NAP - CONVERT update

### DIFF
--- a/connector/doc/EVS_Neuron_NAP_-_CONVERT.md
+++ b/connector/doc/EVS_Neuron_NAP_-_CONVERT.md
@@ -4,47 +4,33 @@ uid: Connector_help_EVS_Neuron_NAP_-_CONVERT
 
 # EVS Neuron NAP - CONVERT
 
-This connector is designed for the monitoring of the convert function of the EVS Neuron.
-
 ## About
 
-### Version Info
+The EVS Neuron NAP - CONVERT connector enables real-time monitoring and control of Neuron Convert devices, which provide high-density video and audio format conversion. This connector allows broadcast operators to manage and supervise conversion operations efficiently within their broadcast environments.
 
-| Range                | Key Features     | Based on     | System Impact     |
-|----------------------|------------------|--------------|-------------------|
-| 1.0.0.x [SLC Main]   | Initial version. | -            | -                 |
+## Key Features
 
-### System Info
+- **Comprehensive device monitoring**: Access detailed device identity, firmware version, and API information for Neuron Convert devices.
+- **Video path and channel monitoring**: Gain full visibility into video processing paths and their associated channels, including input selection, lock status, output format, and deinterlacing settings.
+- **Input format tracking**: Monitor the active, main, and backup input formats per video channel to quickly detect and respond to format mismatches or failovers.
+- **Advanced video processing configuration**: Configure and monitor delay and frame sync settings, audio embedders, RGB gain and color correction, HDR color space conversion, and scaling per video channel.
+- **Flexible polling management**: Use the built-in Polling Manager to control how frequently each data group is retrieved from the device, with support for on-demand polling.
 
-| Range     | DCF Integration     | Cassandra Compliant     | Linked Components     | Exported Components     |
-|-----------|---------------------|-------------------------|-----------------------|-------------------------|
-| 1.0.0.x   | Yes                 | Yes                     | -                     | -                       |
+## Use Case
 
-## Configuration
+**Challenge**: Managing and monitoring complex video format conversion operations across multiple channels in a broadcast environment, where format mismatches or misconfigured processing settings can lead to on-air issues.
 
-### Connections
+**Solution**: The connector provides centralized monitoring and configuration of Neuron Convert devices, offering a structured overview of video processing paths, channels, and their detailed settings — all from within DataMiner.
 
-#### IP Connection
+**Benefit**: Reduces operational overhead and accelerates fault detection by consolidating all conversion device data into a single element, enabling operators to quickly identify misconfigurations or format issues across all channels.
 
-This connector uses a serial connection and requires the following input during element creation:
+## Technical Reference
 
-SERIAL CONNECTION:
+### Prerequisites
 
-- Interface connection:
+- **Network connectivity** is required for IP-based monitoring and control.
+- **Firmware version 6.x** is required.
+- **DataMiner version 10.4.0** or higher is required.
 
-  - **IP address/host**: The polling IP or URL of the destination.
-  - **IP port**: The IP port of the destination (fixed value: *2072*).
-
-## How to use
-
-The connector does not have a polling timer. It only polls the data at element startup; however, there is also a button available that allows you to trigger the polling manually.
-
-After element startup, the connector can also receive events (unsolicited messages).
-
-You can track the progress of this data retrieval through two loading bars. These bars indicate the polling status for the device's functionalities.
-
-## DataMiner Connectivity Framework
-
-The **1.0.0.x** range of the EVS Neuron NAP - CONVERT connector supports the usage of DCF.
-
-DCF can also be implemented through the DataMiner DCF user interface and through third-party DataMiner connectors (e.g., a manager).
+> [!NOTE]
+> For detailed technical information, refer to our [technical documentation](xref:Connector_help_EVS_Neuron_NAP_-_CONVERT_Technical).

--- a/connector/doc/EVS_Neuron_NAP_-_CONVERT.md
+++ b/connector/doc/EVS_Neuron_NAP_-_CONVERT.md
@@ -12,7 +12,7 @@ The EVS Neuron NAP - CONVERT connector enables real-time monitoring and control 
 
 - **Comprehensive device monitoring**: Access detailed device identity, firmware version, and API information for Neuron Convert devices.
 - **Video path and channel monitoring**: Gain full visibility into video processing paths and their associated channels, including input selection, lock status, output format, and deinterlacing settings.
-- **Input format tracking**: Monitor the active, main, and backup input formats per video channel to quickly detect and respond to format mismatches or failovers.
+- **Input format tracking**: Monitor the active, main, and backup input formats per video channel to quickly detect and respond to format mismatches or failover switches.
 - **Advanced video processing configuration**: Configure and monitor delay and frame sync settings, audio embedders, RGB gain and color correction, HDR color space conversion, and scaling per video channel.
 - **Flexible polling management**: Use the built-in Polling Manager to control how frequently each data group is retrieved from the device, with support for on-demand polling.
 

--- a/connector/doc/EVS_Neuron_NAP_-_CONVERT_Technical.md
+++ b/connector/doc/EVS_Neuron_NAP_-_CONVERT_Technical.md
@@ -1,0 +1,77 @@
+---
+uid: Connector_help_EVS_Neuron_NAP_-_CONVERT_Technical
+---
+
+# EVS Neuron NAP - CONVERT
+
+## About
+
+The EVS Neuron NAP - CONVERT connector enables monitoring and control of Neuron Convert devices, which provide high-density video and audio format conversion. This allows real-time visibility and management of conversion operations within broadcast environments.
+
+This connector communicates with the device using the **REST API (v1.0.0)** over **HTTP**. Firmware version **6.x** is required.
+
+### Version Info
+
+| Range | Key Features | Based on | System Impact |
+|--|--|--|--|
+| 1.0.0.x | Initial version. Uses a smart-serial connection with support for unsolicited messages. | - | - |
+| 2.0.0.x [SLC Main] | Redesigned to use REST API over HTTP. No longer supports unsolicited messages. | - | - |
+
+### System Info
+
+| Range | DCF Integration | Cassandra Compliant | Linked Components | Exported Components |
+|--|--|--|--|--|
+| 1.0.0.x | Yes | Yes | - | - |
+| 2.0.0.x | No | Yes | - | - |
+
+## Configuration
+
+### Connections
+
+#### HTTP Main Connection
+
+This connector uses an HTTP connection and requires the following input during element creation:
+
+HTTP CONNECTION:
+
+- **IP address/host**: The polling IP or URL of the destination.
+- **IP port**: The IP port of the destination (fixed value: *2072*).
+
+### Initialization
+
+Once the element has been created in DataMiner, the **General** page allows you to configure the **API Version** used to communicate with the device. On the **Polling Settings** page, you can configure the polling intervals for each data group and enable or disable polling per group.
+
+## How to use
+
+The connector polls data at element startup. On-demand polling can be triggered via the **Polling Settings** page.
+
+### General Page
+
+The **General** page provides essential device identity information, including the **Product Name**, **Product Version**, **Model Version**, and **API Version**. The Element Configuration section on this page allows you to set the API version and access the **Polling Settings** and **Protocol Queue** pages.
+
+### Polling Settings Page
+
+The **Polling Settings** page contains the **Polling Manager** table, which lists all configurable polling groups. For each group you can view and adjust the **polling interval**, **admin status**, and the **last poll result**. This page gives you full control over how frequently each data set is retrieved from the device.
+
+### Protocol Queue Page
+
+The **Protocol Queue** page provides insight into the connector's internal request handling. When changes are made, the connector builds and queues HTTP requests accordingly, and may bundle multiple updates into a single request where possible. This page shows the item currently being processed and the full queue of pending requests, which is useful for understanding connector behavior or diagnosing unexpected communication patterns.
+
+### Video Processing Page
+
+The **Video Processing** page provides a tree control that gives an overview of all configured **video processing paths** and their associated **channels**. This is the main entry point for navigating the conversion processing hierarchy.
+
+### Video Path Processing Page
+
+The **Video Path Processing** page contains a table listing all video paths on the device, including their **input/output wire modes**, **UHD settings**, and **proxy output configuration**.
+
+### Video Channel Processing Page
+
+The **Video Channel Processing** page contains a table listing all video processing channels, including their **assigned path**, **input selection**, **lock status**, **output format**, and **deinterlacer settings**. From this page you can navigate to the following sub-pages:
+
+- **Input Formats**: Lists the **active**, **main**, and **backup input formats** per channel. This allows you to detect format mismatches or active failovers.
+- **Delay & Frame Sync**: Shows the **frame delay**, **vertical and horizontal delay**, **IO delay**, and **frame sync alignment** settings per channel.
+- **Embedders**: Displays and allows configuration of the **audio and data embedder mode** and **audio group selection** per channel.
+- **RGB Gain**: Shows the **RGB gain**, **black levels**, **clipping**, and **hue shift** color correction settings per channel.
+- **HDR Conversion**: Displays the **color space mode**, **input/output color spaces**, **normalization**, **LUT selection**, and **matrix mode** for HDR conversion per channel.
+- **Scaling**: Contains the **scaling conversion mode**, **low-pass filter settings**, and **horizontal sharpness controls** per channel.

--- a/connector/doc/EVS_Neuron_NAP_-_CONVERT_Technical.md
+++ b/connector/doc/EVS_Neuron_NAP_-_CONVERT_Technical.md
@@ -10,20 +10,6 @@ The EVS Neuron NAP - CONVERT connector enables monitoring and control of Neuron 
 
 This connector communicates with the device using the **REST API (v1.0.0)** over **HTTP**. Firmware version **6.x** is required.
 
-### Version Info
-
-| Range | Key Features | Based on | System Impact |
-|--|--|--|--|
-| 1.0.0.x | Initial version. Uses a smart-serial connection with support for unsolicited messages. | - | - |
-| 2.0.0.x [SLC Main] | Redesigned to use REST API over HTTP. No longer supports unsolicited messages. | - | - |
-
-### System Info
-
-| Range | DCF Integration | Cassandra Compliant | Linked Components | Exported Components |
-|--|--|--|--|--|
-| 1.0.0.x | Yes | Yes | - | - |
-| 2.0.0.x | No | Yes | - | - |
-
 ## Configuration
 
 ### Connections
@@ -51,7 +37,7 @@ The **General** page provides essential device identity information, including t
 
 ### Polling Settings Page
 
-The **Polling Settings** page contains the **Polling Manager** table, which lists all configurable polling groups. For each group you can view and adjust the **polling interval**, **admin status**, and the **last poll result**. This page gives you full control over how frequently each data set is retrieved from the device.
+The **Polling Settings** page contains the **Polling Manager** table, which lists all configurable polling groups. For each group, you can view and adjust the **polling interval**, **admin status**, and the **last poll result**. This page gives you full control over how frequently each data set is retrieved from the device.
 
 ### Protocol Queue Page
 

--- a/connector/doc/EVS_Neuron_NAP_-_CONVERT_Technical.md
+++ b/connector/doc/EVS_Neuron_NAP_-_CONVERT_Technical.md
@@ -55,7 +55,7 @@ The **Polling Settings** page contains the **Polling Manager** table, which list
 
 ### Protocol Queue Page
 
-The **Protocol Queue** page provides insight into the connector's internal request handling. When changes are made, the connector builds and queues HTTP requests accordingly, and may bundle multiple updates into a single request where possible. This page shows the item currently being processed and the full queue of pending requests, which is useful for understanding connector behavior or diagnosing unexpected communication patterns.
+The **Protocol Queue** page provides insight into the connector's internal request handling. When changes are made, the connector builds and queues HTTP requests accordingly, and it may bundle multiple updates into a single request where possible. This page shows the item currently being processed and the full queue of pending requests, which is useful for understanding connector behavior or diagnosing unexpected communication patterns.
 
 ### Video Processing Page
 
@@ -69,7 +69,7 @@ The **Video Path Processing** page contains a table listing all video paths on t
 
 The **Video Channel Processing** page contains a table listing all video processing channels, including their **assigned path**, **input selection**, **lock status**, **output format**, and **deinterlacer settings**. From this page you can navigate to the following sub-pages:
 
-- **Input Formats**: Lists the **active**, **main**, and **backup input formats** per channel. This allows you to detect format mismatches or active failovers.
+- **Input Formats**: Lists the **active**, **main**, and **backup input formats** per channel. This allows you to detect format mismatches or active failover switches.
 - **Delay & Frame Sync**: Shows the **frame delay**, **vertical and horizontal delay**, **IO delay**, and **frame sync alignment** settings per channel.
 - **Embedders**: Displays and allows configuration of the **audio and data embedder mode** and **audio group selection** per channel.
 - **RGB Gain**: Shows the **RGB gain**, **black levels**, **clipping**, and **hue shift** color correction settings per channel.

--- a/connector/toc.yml
+++ b/connector/toc.yml
@@ -3997,6 +3997,9 @@
     topicUid: Connector_help_EVS_Neuron_NAP_-_COMPRESS
   - name: EVS Neuron NAP - CONVERT
     topicUid: Connector_help_EVS_Neuron_NAP_-_CONVERT
+    items:
+      - name: EVS Neuron NAP - CONVERT Technical
+        topicUid: Connector_help_EVS_Neuron_NAP_-_CONVERT_Technical
   - name: EVS Neuron NAP - PROTECT
     topicUid: Connector_help_EVS_Neuron_NAP_-_PROTECT
   - name: EVS XS


### PR DESCRIPTION
Added a marketing page for the EVS Neuron NAP - CONVERT. Since it didn't have one. 
Moved the other things to the technical page. 
It now references the new range 2.0.0.X with the new features. 

Currently the connector version change is pending.