### PR TITLE
Update Cassandra Compliant status for firmware version 2.0.1.x

### DIFF
--- a/connector/doc/Stagetec_Nexus_Star.md
+++ b/connector/doc/Stagetec_Nexus_Star.md
@@ -19,7 +19,7 @@ This connector retrieves data via **Smart-Serial Communication** over **UDP**.
 | 1.0.1.x               | RedundantPolling IP Address (warning, needs a new element)                                            | No                  | Yes                     |
 | 1.0.2.x (RTBF)        | Permanent Connection using Keep Alive - ACK (Can be directly upgraded from elements of range 1.0.0.x) | No                  | Yes                     |
 | 2.0.0.x               | Review - Customer Mecca                                                                        | No                  | Yes                     |
-| 2.0.1.x (Main Branch) | Complete Review                                                                                | No                  | No                      |
+| 2.0.1.x (Main Branch) | Complete Review                                                                                | No                  | Yes                      |
 
 ### Product Info
 


### PR DESCRIPTION
Checked with code owner and connector of 2.0.1.x range should be cassandra compliant.