### PR TITLE
OneWeb Enterprise: Product Inventory V4 Update 

### DIFF
--- a/connector/doc/OneWeb_Enterprise_Technical.md
+++ b/connector/doc/OneWeb_Enterprise_Technical.md
@@ -55,7 +55,7 @@ User terminal components (e.g., "AIM","CNX", "EGR", "MDM", "MIM", "SSM") metadat
 
 ### Products
 
-The **Products** page retrieves the inventory of service plan products. It displays a list of available products, each identified by a unique identifier and name. Each product is linked to a distribution partner and a specific site, establishing its deployment context.
+The **Products** page retrieves the inventory of service plan products. It displays a list of available products, each identified by a unique identifier (Parent pooled plans IDs start with POOL-XXXX, Sub-plans and standard Site Connectivity plans IDs start with SC-XXXX) and name. Each product is linked to a distribution partner and a specific site, establishing its deployment context.
 
 A key aspect of this page is the relationship between products and user terminals — each product is associated with the IMEI of the terminal utilizing the service. Additionally, products are connected to end customer accounts and sites, providing a complete view of ownership and location.
 


### PR DESCRIPTION
## Summary

Updated the OneWeb Enterprise technical documentation to include details about the new Site Connectivity plan ID format.

## Changes

- Added information that parent pooled plan IDs use the format `POOL-XXXXX`.
- Clarified that sub-plans and standard Site Connectivity plans continue to use the format `SC-XXXXX`.

## Testing

- Documentation change only.
- No functional changes.
