### PR TITLE
Add Huawei iMaster MAE connector help page

### DIFF
--- a/connector/doc/Huawei_iMaster_MAE.md
+++ b/connector/doc/Huawei_iMaster_MAE.md
@@ -1,0 +1,34 @@
+---
+uid: Connector_help_Huawei_iMaster_MAE
+---
+
+# Huawei iMaster MAE
+
+## About
+
+The Huawei iMaster MAE connector integrates the Huawei iMaster MAE-Access management system into DataMiner. It ingests SNMPv3 alarm and heartbeat traps forwarded by the iMaster MAE northbound interface and enriches the picture with a daily network element (NE) inventory retrieved over SFTP.
+
+This connector gives operators a real-time view of alarms raised across the managed access network, tracks the availability of the northbound feed through a heartbeat watchdog, and maintains an up-to-date inventory of all network elements.
+
+## Key Features
+
+- **SNMPv3 trap ingestion**: Receives and processes alarm traps from the iMaster MAE northbound interface in real time, presenting them in a dedicated Alarms Overview table with severity and alarm status.
+
+- **Heartbeat watchdog**: Monitors periodic heartbeat traps and derives a device availability state, so a loss of the northbound feed is detected and can be alarmed even when no alarm traps are arriving.
+
+- **Daily inventory synchronization**: Automatically downloads the daily NE inventory CSV export over SFTP and refreshes a full inventory table, with an on-demand "Force Update" option.
+
+- **Alarm template ready**: Key status parameters are monitored so alarm severities can be assigned through DataMiner alarm templates.
+
+## Use Case
+
+**Challenge**: Operators managing a large Huawei access network need a single, real-time view of alarms and network element inventory, without logging into the iMaster MAE system directly.
+
+**Solution**: Use the Huawei iMaster MAE connector to ingest northbound SNMP traps and synchronize the daily inventory export into DataMiner, consolidating alarms and inventory in one place.
+
+**Benefit**: Faster alarm response, continuous visibility into the health of the northbound feed, and an always-current inventory of managed network elements.
+
+## Technical Reference
+
+> [!NOTE]
+> For detailed technical information, refer to our [technical documentation](xref:Connector_help_Huawei_iMaster_MAE_Technical).

--- a/connector/doc/Huawei_iMaster_MAE_Technical.md
+++ b/connector/doc/Huawei_iMaster_MAE_Technical.md
@@ -1,0 +1,69 @@
+---
+uid: Connector_help_Huawei_iMaster_MAE_Technical
+---
+
+# Huawei iMaster MAE
+
+## About
+
+The Huawei iMaster MAE connector integrates the Huawei iMaster MAE-Access management system into DataMiner. It processes SNMPv3 alarm and heartbeat traps forwarded by the iMaster MAE northbound interface and synchronizes a daily network element (NE) inventory retrieved over SFTP.
+
+Alarm traps are stored in an Alarms Overview table, heartbeat traps drive a device availability watchdog, and the inventory export is parsed and loaded into a dedicated Inventory table.
+
+## Configuration
+
+### Connections
+
+#### SNMP Connection - Main
+
+This connector uses an SNMPv3 connection and requires the following input during element creation:
+
+SNMP CONNECTION:
+
+- **IP address/host**: The polling IP of the Huawei iMaster MAE-Access node.
+- **Device address**: The device address of the node.
+
+SNMP Settings:
+
+- **IP port**: The IP port used for the SNMP connection.
+- **Security settings**: The SNMPv3 credentials (username, authentication, and privacy settings) as configured on the iMaster MAE northbound interface.
+
+### Initialization
+
+After the element has been created, configure the following on the *Configuration* page before the connector can be fully used:
+
+- **SFTP Host**: The host name or IP address of the SFTP server hosting the daily inventory CSV export.
+- **SFTP Username** and **SFTP Password**: The credentials used to authenticate to the SFTP server.
+- **SFTP Remote Directory**: The remote directory containing the daily inventory CSV export (for example, `/opt/oss/server/var/fileint/cm/Report/`).
+- **Heartbeat Timeout**: The number of seconds without a heartbeat trap after which the device is considered *Unavailable* (default: 180s).
+
+Until the SFTP settings are filled in, the inventory table is not populated and the *Last Inventory Result* parameter indicates that the connector is not yet configured.
+
+To monitor alarm states, attach an alarm template to the monitored parameters (for example *Device Availability* and the alarm trap severity), so severities are assigned through the template.
+
+## How to Use
+
+The connector is trap-driven: no active polling of the device takes place for alarms and heartbeats. Alarm and heartbeat traps must be forwarded from the iMaster MAE northbound interface to the DataMiner Agent. Because there is no active polling for these, no request/response traffic is visible in the Stream Viewer for the trap flows.
+
+### General Page
+
+Displays high-level statistics, including the number of active alarms and the inventory row count.
+
+### Inventory Page
+
+Displays the network element inventory loaded from the daily CSV export, keyed on NE Name. Each refresh upserts the rows found in the file and removes rows for NEs no longer present.
+
+### Alarms Page
+
+Displays the Alarms Overview table populated from received alarm traps, including severity (Alarm State), Alarm Status (Active/Cleared), and timestamps.
+
+### Configuration Page
+
+Contains the device status parameters (last heartbeat received, time since last trap, device availability, heartbeat timeout), the SNMP trap section, the SFTP configuration, and the inventory status.
+
+- **Force Update Inventory**: Triggers an immediate download and refresh of the inventory CSV, bypassing the once-per-day guard used by the automatic hourly polling.
+
+## Notes
+
+- The inventory refresh is guarded to run once per day; the automatic hourly poll keeps retrying until the file dated for the current day has been loaded.
+- The Alarms Overview table currently holds trap-sourced alarms only and is cleared on element restart.

--- a/connector/toc.yml
+++ b/connector/toc.yml
@@ -5157,6 +5157,11 @@
     topicUid: Connector_help_Huawei_iManager_U2000_Element
   - name: Huawei iManager U2000 SNMP
     topicUid: Connector_help_Huawei_iManager_U2000_SNMP
+  - name: Huawei iMaster MAE
+    topicUid: Connector_help_Huawei_iMaster_MAE
+    items:
+    - name: Huawei iMaster MAE Technical
+      topicUid: Connector_help_Huawei_iMaster_MAE_Technical
   - name: Huawei iMaster NCE
     topicUid: Connector_help_Huawei_iMaster_NCE
   - name: Huawei iMaster NCE - Network Element

--- a/connector/toc.yml
+++ b/connector/toc.yml
@@ -7565,9 +7565,9 @@
   items:
   - name: Observium Network Platform
     topicUid: Connector_help_Observium_Network_Platform
-    - items:
-      - name: Observium Network Platform Technical
-        topicUid: Connector_help_Observium_Network_Platform_Technical
+    items:
+    - name: Observium Network Platform Technical
+      topicUid: Connector_help_Observium_Network_Platform_Technical
 - name: Ocean Controls
   items:
   - name: Ocean Controls KTA-282 Weather Station Gateway


### PR DESCRIPTION
## Note for reviewers
While adding the Huawei iMaster MAE help pages, the docfx build failed on an
unrelated, pre-existing YAML error in the **Observium Network Platform** entry
in `connector/toc.yml` (malformed `- items:` indentation, ~line 7568).
Since docfx validates the entire TOC, I fixed that entry as well so the build
can pass. This change is unrelated to the Huawei connector itself.